### PR TITLE
add support for macOS and panic on not supported platform

### DIFF
--- a/pycqBot/cqHttpApi.py
+++ b/pycqBot/cqHttpApi.py
@@ -330,7 +330,11 @@ class cqBot(cqEvent.Event):
                 subp = subprocess.Popen("cd %s && .\go-cqhttp.exe -faststart" % go_cqhttp_path, shell=True, stdout=subprocess.PIPE)
             elif plat == 'linux':
                 subp = subprocess.Popen("cd %s && ./go-cqhttp -faststart" % go_cqhttp_path, shell=True, stdout=subprocess.PIPE)
-
+            elif plat == 'darwin':
+                subp = subprocess.Popen("cd %s && ./go-cqhttp -faststart" % go_cqhttp_path, shell=True, stdout=subprocess.PIPE)
+            else 
+                print("unsupported system: ", plat)
+                sys.exit(1)
             while self._start_in:
                 shell_msg = subp.stdout.readline().decode("utf-8").strip()
                 if shell_msg.strip() == "":


### PR DESCRIPTION
add support for macOS  and panic on not supported platform

origin version has no error message running on platform other than windows and linux, but it actually can work under macOS using the same command of linux to init subp in macOS.

so I add some branch to be able to init subp in macOS, and can panic and print error message on other platforms