### PR TITLE
修复了接收到表情包时报错的问题

### DIFF
--- a/pycqBot/cqHttpApi.py
+++ b/pycqBot/cqHttpApi.py
@@ -718,7 +718,7 @@ class cqBot(cqEvent.Event):
         指令解析
         """
 
-        if self.commandSign != "":
+        if self.commandSign != "" and list(message):
             commandSign = list(message)[0]
         else:
             commandSign = ""


### PR DESCRIPTION
![image](https://github.com/FengLiuFeseliud/pycqBot/assets/62163341/8a941a69-0e06-4f5a-8520-76ff71387067)
一个概率触发的bug，群友发送表情包时有时list(message)会是一个空列表，导致命令解析时莫名其妙报错