### PR TITLE
使用项目logger而不是系统默认logging全局记录

### DIFF
--- a/pycqBot/asyncHttp.py
+++ b/pycqBot/asyncHttp.py
@@ -1,5 +1,5 @@
 from typing import Any, Coroutine, Optional
-import logging
+from pycqBot.cqLogger import cqlogger
 from threading import Thread
 import asyncio
 import aiohttp
@@ -43,10 +43,10 @@ class asyncHttp:
 
         json = await self.link("%s%s" % (self.http, api), mod="post", data=data)
         if json == {} or json is None:
-            logging.warning("cqAPI 响应: None / {}")
+            cqlogger.warning("cqAPI 响应: None / {}")
             return None
 
-        logging.debug("cqAPI 响应: %s" % json)
+        cqlogger.debug("cqAPI 响应: %s" % json)
             
         if json["retcode"] != 0:
             self.apiLinkError(json)
@@ -88,7 +88,7 @@ class asyncHttp:
         try:
             with requests.post(f"{self.http}{api}", data=data) as req:
                 json =  req.json()
-                logging.debug("cqAPI 响应: %s" % json)
+                cqlogger.debug("cqAPI 响应: %s" % json)
                 if json["retcode"] != 0:
                     self.apiLinkError(json)
                     
@@ -147,30 +147,30 @@ class asyncHttp:
         """
         下载完成
         """
-        logging.info("%s 下载完成! code: %s" % (file_name, code))
+        cqlogger.info("%s 下载完成! code: %s" % (file_name, code))
 
     def downloadFileError(self, file_name: str, file_url: str, code: int) -> None:
         """
         下载失败
         """
-        logging.error("%s 下载失败... code: %s" % (file_name, code))
+        cqlogger.error("%s 下载失败... code: %s" % (file_name, code))
     
     def downloadFileRunError(self, err: Exception) -> None:
         """
         下载时发生错误
         """
-        logging.error("下载文件时发生错误 Error: %s" % err)
-        logging.exception(err)
+        cqlogger.error("下载文件时发生错误 Error: %s" % err)
+        cqlogger.exception(err)
     
     def apiLinkError(self, err_json: dict) -> None:
         """
         cqapi发生错误
         """
-        logging.error("api 发生错误 %s: %s code: %s" % (err_json["msg"], err_json["wording"], err_json["retcode"]))
+        cqlogger.error("api 发生错误 %s: %s code: %s" % (err_json["msg"], err_json["wording"], err_json["retcode"]))
     
     def apiLinkRunError(self, err: Exception) -> None:
         """
         cqapi请求时发生错误
         """
-        logging.error("api 请求发生错误 Error: %s" % err)
-        logging.exception(err)
+        cqlogger.error("api 请求发生错误 Error: %s" % err)
+        cqlogger.exception(err)

--- a/pycqBot/cqLogger.py
+++ b/pycqBot/cqLogger.py
@@ -1,0 +1,24 @@
+import logging
+from logging.handlers import TimedRotatingFileHandler
+import os
+
+cqlogger = logging.getLogger('pycqBot')
+cqlogger.setLevel(logging.CRITICAL)
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+console_handler.setFormatter(formatter)
+
+
+def enable_logging(logPath, when, interval, backupCount):
+    cqlogger.setLevel(logging.DEBUG)
+    file_handler = TimedRotatingFileHandler(
+        os.path.join(logPath, "cq.log"),
+        when,
+        interval,
+        backupCount,
+        encoding='utf-8'
+    )
+    file_handler.setFormatter(formatter)
+    cqlogger.addHandler(file_handler)
+    cqlogger.addHandler(console_handler)

--- a/pycqBot/plugin/bilibili/bilibili.py
+++ b/pycqBot/plugin/bilibili/bilibili.py
@@ -1,11 +1,11 @@
 import json
-import logging
 import requests
 import time
 from lxml import etree
 from pycqBot.cqHttpApi import cqBot, cqHttpApi
 from pycqBot.cqCode import image
 from pycqBot.object import Message, Plugin
+from pycqBot.cqLogger import cqlogger
 
 
 class bilibili(Plugin):
@@ -219,7 +219,7 @@ class bilibili(Plugin):
                 return
 
             message.reply_not_code(link_message)
-            logging.debug("解析到了分享信息 %s" % link_message)
+            cqlogger.debug("解析到了分享信息 %s" % link_message)
         except Exception as err:
             self.getShareVideoError(err)
     
@@ -506,7 +506,7 @@ class bilibili(Plugin):
                     self._lives_old.remove(live_id)
                     live_end_message = self.set_live_end_message(live_list["data"][live_id])
                     self._send_msg_list.append(live_end_message)
-                    logging.debug("监听到了下播 %s" % live_end_message)
+                    cqlogger.debug("监听到了下播 %s" % live_end_message)
 
                 continue
 
@@ -516,7 +516,7 @@ class bilibili(Plugin):
             live_message = self.set_live_message(live_list["data"][live_id])
             self._send_msg_list.append(live_message)
             self._lives_old.append(live_id)
-            logging.debug("监听到了开播 %s" % live_message)
+            cqlogger.debug("监听到了开播 %s" % live_message)
     
     async def _dynamic_check(self, dynamic):
         dynamic = self._dynamic_type_check(
@@ -559,14 +559,14 @@ class bilibili(Plugin):
                     self._dynamic_list_old[uid]["data"])
                 )
                 self._send_msg_list.append(dynamic)
-                logging.debug("监听到了动态删除 %s" % dynamic)
+                cqlogger.debug("监听到了动态删除 %s" % dynamic)
                 continue
             
             dynamic = await self._dynamic_check(
                     dynamic_list[uid]["data"]
                 )
             self._send_msg_list.append(dynamic)
-            logging.debug("监听到了新的动态 %s" % dynamic)
+            cqlogger.debug("监听到了新的动态 %s" % dynamic)
 
         self._dynamic_list_old = dynamic_list
     
@@ -620,25 +620,25 @@ class bilibili(Plugin):
         """
         监听直播信息时错误
         """
-        logging.error("监听直播信息发生错误! Error: %s" % err)
-        logging.exception(err)
+        cqlogger.error("监听直播信息发生错误! Error: %s" % err)
+        cqlogger.exception(err)
 
     def monitorDynamicError(self, err):
         """
         监听动态信息时错误
         """
-        logging.error("监听动态信息发生错误! Error: %s" % err)
-        logging.exception(err)
+        cqlogger.error("监听动态信息发生错误! Error: %s" % err)
+        cqlogger.exception(err)
     
     def getShareVideoError(self, err):
         """
         解析分享信息时错误
         """
-        logging.error("解析分享信息发生错误! Error: %s" % err)
-        logging.exception(err)
+        cqlogger.error("解析分享信息发生错误! Error: %s" % err)
+        cqlogger.exception(err)
     
     def biliApiError(self, code, err_msg):
         """
         请求 bilibili api 时错误
         """
-        logging.error("请求 bilibili api发生错误! Error: %s code:%s" % (err_msg, code))
+        cqlogger.error("请求 bilibili api发生错误! Error: %s code:%s" % (err_msg, code))

--- a/pycqBot/plugin/manage/manage.py
+++ b/pycqBot/plugin/manage/manage.py
@@ -1,4 +1,4 @@
-import logging
+from pycqBot.cqLogger import cqlogger
 from pycqBot.cqHttpApi import cqBot, cqHttpApi
 from pycqBot.object import Plugin
 from pycqBot.data import *
@@ -84,10 +84,10 @@ class manage(Plugin):
     def request_group_invite(self, event: Request_Event):
         if self._group_request_all:
             self.cqapi.set_group_add_request(event.data["flag"], event.data["sub_type"], True)
-            logging.info("接受来自 qq=%s 的 group_id=%s 群邀请" % (event.data["user_id"],event.data["group_id"] ))
+            cqlogger.info("接受来自 qq=%s 的 group_id=%s 群邀请" % (event.data["user_id"],event.data["group_id"] ))
             return
         
-        logging.info("保存来自 qq=%s 的 group_id=%s 群邀请" % (event.data["user_id"],event.data["group_id"] ))
+        cqlogger.info("保存来自 qq=%s 的 group_id=%s 群邀请" % (event.data["user_id"],event.data["group_id"] ))
         self._request_group_message_list.append(event.data)
 
     def notice_group_recall(self, event: Notice_Event):

--- a/pycqBot/plugin/pixiv/pixiv.py
+++ b/pycqBot/plugin/pixiv/pixiv.py
@@ -1,6 +1,6 @@
-import logging
 import random
 from lxml import etree
+from pycqBot.cqLogger import cqlogger
 from pycqBot.cqHttpApi import cqBot, cqHttpApi
 from pycqBot.cqCode import image, node_list
 from pycqBot.object import Plugin
@@ -391,52 +391,52 @@ class pixiv(Plugin):
         """
         搜索随机图片时错误
         """
-        logging.error("搜索 %s 随机图片时发生错误! Error: %s " % (search_data, err))
-        logging.exception(err)
+        cqlogger.error("搜索 %s 随机图片时发生错误! Error: %s " % (search_data, err))
+        cqlogger.exception(err)
     
     def randomSearchUserImageError(self, user_name, rlen, nick, err):
         """
         随机用户作品时错误
         """
-        logging.error("随机 %s 作品时发生错误! Error: %s " % (user_name, err))
-        logging.exception(err)
+        cqlogger.error("随机 %s 作品时发生错误! Error: %s " % (user_name, err))
+        cqlogger.exception(err)
     
     def randomSearchFollowingImageError(self, err):
         """
         随机关注用户作品时发生错误
         """
-        logging.error("随机关注用户作品时发生错误! Error: %s " % err)
-        logging.exception(err)
+        cqlogger.error("随机关注用户作品时发生错误! Error: %s " % err)
+        cqlogger.exception(err)
     
     def searchPidError(self, pid_list, err):
         """
         搜索PID时发生错误
         """
-        logging.error("搜索 PID %s 时发生错误! Error: %s " % (pid_list, err))
-        logging.exception(err)
+        cqlogger.error("搜索 PID %s 时发生错误! Error: %s " % (pid_list, err))
+        cqlogger.exception(err)
     
     def getImageError(self, img_id, err):
         """
         搜索图片时发生错误
         """
-        logging.error("搜索图片 %s 时发生错误! Error: %s " % (img_id, err))
-        logging.exception(err)
+        cqlogger.error("搜索图片 %s 时发生错误! Error: %s " % (img_id, err))
+        cqlogger.exception(err)
     
     def getUserError(self, user_name, nick, err):
         """
         搜索用户时发生错误
         """
-        logging.error("搜索用户 %s 时发生错误! Error: %s " % (user_name, err))
-        logging.exception(err)
+        cqlogger.error("搜索用户 %s 时发生错误! Error: %s " % (user_name, err))
+        cqlogger.exception(err)
     
     def getFollowingError(self, following_data):
         """
         获取关注用户时发生错误
         """
-        logging.error("获取关注用户时发生错误! Error: %s " % following_data)
+        cqlogger.error("获取关注用户时发生错误! Error: %s " % following_data)
 
     def pixivApiError(self, err_msg):
         """
         请求 pixiv api 时错误
         """
-        logging.error("请求 pixiv api发生错误! Error: %s " % err_msg)
+        cqlogger.error("请求 pixiv api发生错误! Error: %s " % err_msg)

--- a/pycqBot/plugin/twitter/twitter.py
+++ b/pycqBot/plugin/twitter/twitter.py
@@ -1,8 +1,7 @@
-import logging
 import time
 from pycqBot.object import Plugin
 from pycqBot.cqHttpApi import cqBot, cqHttpApi
-
+from pycqBot.cqLogger import cqlogger
 
 class twitter(Plugin):
     """
@@ -27,7 +26,7 @@ class twitter(Plugin):
         }
         self._user_list = plugin_config["monitor"]
         if self._user_list is None:
-            logging.warning("twitter 插件未配置 monitor 中止加载")
+            cqlogger.warning("twitter 插件未配置 monitor 中止加载")
             return
 
         self._user_id_list = []
@@ -131,11 +130,11 @@ class twitter(Plugin):
         """
         推特 api 错误
         """
-        logging.error("推特 api 错误 code: %s error: %s" % (code, error))
+        cqlogger.error("推特 api 错误 code: %s error: %s" % (code, error))
     
     def monitorTweetsError(self, err):
         """
         推文更新错误
         """
-        logging.error("监听推文更新错误 error: %s" % err)
-        logging.exception(err)
+        cqlogger.error("监听推文更新错误 error: %s" % err)
+        cqlogger.exception(err)

--- a/pycqBot/plugin/weather/weather.py
+++ b/pycqBot/plugin/weather/weather.py
@@ -1,8 +1,9 @@
 import json
-import logging
+from pycqBot.cqLogger import cqlogger
 from pycqBot.object import Plugin
 from pycqBot.cqHttpApi import cqBot, cqHttpApi
 from pycqBot.data import *
+
 
 class weather(Plugin):
     """
@@ -29,20 +30,20 @@ class weather(Plugin):
                 ganmao = data["data"]["ganmao"]
                 data = data["data"]["forecast"][0]
                 fengli = data["fengli"].lstrip("<![CDATA[").rstrip("]]>")
-                message_data = "%s%s %s %s %s %s%s\n%s" % (city, data["date"], 
-                    data["high"],
-                    data["low"],
-                    data["type"],
-                    data["fengxiang"],
-                    fengli,
-                    ganmao
-                )
+                message_data = "%s%s %s %s %s %s%s\n%s" % (city, data["date"],
+                                                           data["high"],
+                                                           data["low"],
+                                                           data["type"],
+                                                           data["fengxiang"],
+                                                           fengli,
+                                                           ganmao
+                                                           )
 
             print(message_data)
             message.reply(message_data)
         except Exception as err:
-            logging.error("天气 error: %s" % err)
-            logging.exception(err)
+            cqlogger.error("天气 error: %s" % err)
+            cqlogger.exception(err)
 
     def weather(self, commandData, message: Message):
         self.cqapi.add_task(self._weather(commandData[0], message))


### PR DESCRIPTION
- BUG描述：在pycqBot中，默认使用logging.debug()输出日志，而不是首先通过logging.getLogger设置logger来输出日志，这样如果我在其他项目中使用logging模块记录自己的日志时候，就会导致输出混乱，以下代码可以复现输出结果。最后一行logger.debug('Log 3, BAD!')，理应只输出`2023-08-31 22:16:16,799 - mylogger - DEBUG - Log 3, BAD!`这一行，但是却多了`DEBUG:mylogger:Log 3, BAD!`

```
import logging

logger = logging.getLogger('mylogger')
logger.setLevel(logging.DEBUG)
ch = logging.StreamHandler()
ch.setLevel(logging.DEBUG)
formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
ch.setFormatter(formatter)
logger.addHandler(ch)
logger.debug('Log 1, OK!')
logger.debug('Log 2, OK!')
logging.critical('Log using logging')
logger.debug('Log 3, BAD!')
#example output
#2023-08-31 22:16:16,799 - mylogger - DEBUG - Log 1, OK!
#2023-08-31 22:16:16,799 - mylogger - DEBUG - Log 2, OK!
#CRITICAL:root:Log using logging
#2023-08-31 22:16:16,799 - mylogger - DEBUG - Log 3, BAD!
#DEBUG:mylogger:Log 3, BAD!
```




- PR描述：在pycqLogger.py中定义了logger，通过该logger去输出日志则不会导致输出混乱